### PR TITLE
fix/wrong-arch-detection

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -15,7 +15,7 @@ get_cpu() {
     local machine_hardware_name
     local cpu_type
     machine_hardware_name="$(arch)"
-  
+
     case "$machine_hardware_name" in
         'x86_64') cpu_type="amd64";;
         'powerpc64le' | 'ppc64le') cpu_type="ppc64le";;

--- a/bin/install
+++ b/bin/install
@@ -14,8 +14,8 @@ get_arch() {
 get_cpu() {
     local machine_hardware_name
     local cpu_type
-    machine_hardware_name="$(uname -m)"
-
+    machine_hardware_name="$(arch)"
+  
     case "$machine_hardware_name" in
         'x86_64') cpu_type="amd64";;
         'powerpc64le' | 'ppc64le') cpu_type="ppc64le";;


### PR DESCRIPTION
On macos with arm architecture (M1 Apple Silicon), uname may return 
```
uname -a
Darwin FR-XXX.local 21.6.0 Darwin Kernel Version 21.6.0: Mon Aug 22 20:20:05 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T8101 x86_64 i386 MacBookPro17,1 Darwin
```

Currently this asdf-aws-vault plugin will download amd64 version of aws-vault.
```
asdf plugin-add aws-vault https://github.com/karancode/asdf-aws-vault.git && asdf install aws-vault 6.6.0
Downloading aws-vault from https://github.com/99designs/aws-vault/releases/download/v6.6.0/aws-vault-darwin-amd64.dmg

asdf plugin remove aws-vault
```

With this fix:
```
asdf plugin-add aws-vault https://github.com/JBOClara/asdf-aws-vault.git && asdf install aws-vault 6.6.0
Downloading aws-vault from https://github.com/99designs/aws-vault/releases/download/v6.6.0/aws-vault-darwin-arm64.dmg
```