### PR TITLE
Use maintained aws-vault fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-aws-vault
 ![GitHub Actions Status](https://github.com/karancode/asdf-aws-vault/workflows/Main%20workflow/badge.svg?branch=main)  
-[aws-vault](https://github.com/99designs/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+[aws-vault](https://github.com/ByteNess/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # asdf-aws-vault
-![GitHub Actions Status](https://github.com/karancode/asdf-aws-vault/workflows/Main%20workflow/badge.svg?branch=main)  
+
 [aws-vault](https://github.com/ByteNess/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Install
 
 ```
-asdf plugin-add aws-vault https://github.com/karancode/asdf-aws-vault.git
+asdf plugin-add aws-vault https://github.com/asdf-community/asdf-aws-vault.git
 asdf install aws-vault <version>
 ```
 
@@ -15,5 +15,6 @@ Check out the [asdf documentation](https://asdf-vm.com/guide/getting-started.htm
 
 ## Crediits
 
+- Original [asdf-aws-vault](https://github.com/karancode/asdf-aws-vault) plugin by karancode
 - [asdf-kubectl](https://github.com/asdf-community/asdf-kubectl) plugin
 - [asdf-plugin-template](https://github.com/asdf-vm/asdf-plugin-template)

--- a/bin/install
+++ b/bin/install
@@ -31,9 +31,9 @@ get_download_url() {
     local version="$1"
     local platform="$(get_arch)"
     if [ "$platform" = "darwin" ]; then
-        echo "https://github.com/99designs/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu).dmg"
+        echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu).dmg"
     else
-        echo "https://github.com/99designs/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu)"
+        echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu)"
     fi
 }
 

--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,11 @@ ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version  }
 [ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
 
 get_arch() {
-    uname | tr '[:upper:]' '[:lower:]'
+    local os="$(uname | tr '[:upper:]' '[:lower:]')"
+    case "$os" in
+        'msys'*|'cygwin'*|'mingw'*) echo "windows";;
+        *) echo "$os";;
+    esac
 }
 
 get_cpu() {
@@ -30,11 +34,15 @@ get_cpu() {
 get_download_url() {
     local version="$1"
     local platform="$(get_arch)"
-    if [ "$platform" = "darwin" ]; then
-        echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu).dmg"
-    else
-        echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu)"
+    local cpu="$(get_cpu)"
+    local filename="aws-vault-${platform}-${cpu}"
+
+    # Add .exe extension for Windows
+    if [ "$platform" = "windows" ]; then
+        filename="${filename}.exe"
     fi
+
+    echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/${filename}"
 }
 
 install_aws_vault() {
@@ -49,17 +57,6 @@ install_aws_vault() {
     local bin_path="${bin_install_path}/aws-vault"
     echo "Downloading aws-vault from ${download_url}"
     if curl -sfL "$download_url" -o "$bin_path"; then
-        if [[ "$download_url" = *"dmg" ]]; then
-            # mount
-            hdiutil attach -nobrowse "$bin_path" -quiet
-
-            # replace dmg with binary
-            rm -rf  "$bin_path"
-            cp /Volumes/aws-vault/aws-vault "$bin_path"
-
-            # unmount
-            hdiutil detach /Volumes/aws-vault -quiet
-        fi
         chmod +x $bin_path
     else
         exit 1

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,7 +8,7 @@ function sort_versions() {
 }
 
 list_all_versions() {
-  git ls-remote --tags --refs https://github.com/99designs/aws-vault.git |
+  git ls-remote --tags --refs https://github.com/ByteNess/aws-vault.git |
     grep -o 'refs/tags/.*' |
     cut -d/ -f3- |
     sed 's/^v//'


### PR DESCRIPTION
Hello!

The [original aws-vault](https://github.com/99designs/aws-vault) project by 99designs appears to be abandoned and has some bugs.

There is a [maintained fork](https://github.com/ByteNess/aws-vault) by ByteNess with active development.  

Homebrew, macports, and chocolatey package managers all install the forked version.

So, I think it would make sense for this asdf plugin to use the forked version.