### PR TITLE
Switch to a aws-vault fork maintained by ByteNess

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # asdf-aws-vault
-![GitHub Actions Status](https://github.com/karancode/asdf-aws-vault/workflows/Main%20workflow/badge.svg?branch=main)  
+[![Main workflow](https://github.com/karancode/asdf-aws-vault/actions/workflows/test.yaml/badge.svg)](https://github.com/karancode/asdf-aws-vault/actions/workflows/test.yaml)  
 [aws-vault](https://github.com/99designs/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-aws-vault
 [![Main workflow](https://github.com/karancode/asdf-aws-vault/actions/workflows/test.yaml/badge.svg)](https://github.com/karancode/asdf-aws-vault/actions/workflows/test.yaml)  
-[aws-vault](https://github.com/99designs/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+[aws-vault](https://github.com/ByteNess/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Install
 

--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,6 @@ get_cpu() {
         'x86_64') cpu_type="amd64";;
         'powerpc64le' | 'ppc64le') cpu_type="ppc64le";;
         'aarch64') cpu_type="arm64";;
-        'armv7l') cpu_type="arm";;
         *) cpu_type="$machine_hardware_name";;
     esac
 
@@ -30,11 +29,7 @@ get_cpu() {
 get_download_url() {
     local version="$1"
     local platform="$(get_arch)"
-    if [ "$platform" = "darwin" ]; then
-        echo "https://github.com/99designs/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu).dmg"
-    else
-        echo "https://github.com/99designs/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu)"
-    fi
+    echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu)"
 }
 
 install_aws_vault() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,7 +8,7 @@ function sort_versions() {
 }
 
 list_all_versions() {
-  git ls-remote --tags --refs https://github.com/99designs/aws-vault.git |
+  git ls-remote --tags --refs https://github.com/ByteNess/aws-vault.git |
     grep -o 'refs/tags/.*' |
     cut -d/ -f3- |
     sed 's/^v//'


### PR DESCRIPTION
The original aws-vault repo by 99designs seems to be abandoned. The last release (v7.2.0) is as of now 2.5 years old. See also https://github.com/99designs/aws-vault/issues/1269 .
    
ByteNess created an active fork (current release v7.8.0) which is now also used by Homebrew (https://formulae.brew.sh/formula/aws-vault)