### PR TITLE
feat!: switch to maintained ByteNess aws-vault fork

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,6 @@ jobs:
 
     steps:
       - name: asdf plugin test
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v4.0.1
         with:
           command: aws-vault --version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-aws-vault
 ![GitHub Actions Status](https://github.com/karancode/asdf-aws-vault/workflows/Main%20workflow/badge.svg?branch=main)  
-[aws-vault](https://github.com/99designs/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+[aws-vault](https://github.com/ByteNess/aws-vault) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Install
 
@@ -13,7 +13,11 @@ asdf install aws-vault <version>
 
 Check out the [asdf documentation](https://asdf-vm.com/guide/getting-started.html#_5-install-a-version) for instructions on how to install and manage versions of aws-vault.
 
-## Crediits
+## Supported platforms
+
+macOS and Linux on `amd64`/`arm64`, using `aws-vault` `>= 7.5.0` (earlier versions predate the [ByteNess](https://github.com/ByteNess/aws-vault) fork's per-platform binaries, so only `>= 7.5.0` is listed). Other platforms such as FreeBSD and Linux `ppc64le` work for some versions but are not guaranteed.
+
+## Credits
 
 - [asdf-kubectl](https://github.com/asdf-community/asdf-kubectl) plugin
 - [asdf-plugin-template](https://github.com/asdf-vm/asdf-plugin-template)

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+[ -n "${ASDF_INSTALL_VERSION:-}" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
+[ -n "${ASDF_DOWNLOAD_PATH:-}" ] || (>&2 echo 'Missing ASDF_DOWNLOAD_PATH' && exit 1)
+
+mkdir -p "$ASDF_DOWNLOAD_PATH"
+download_binary "$ASDF_INSTALL_VERSION" "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}"

--- a/bin/install
+++ b/bin/install
@@ -13,28 +13,30 @@ get_arch() {
 
 get_cpu() {
     local machine_hardware_name
-    local cpu_type
     machine_hardware_name="$(uname -m)"
 
-    case "$machine_hardware_name" in
-        'x86_64') cpu_type="amd64";;
-        'powerpc64le' | 'ppc64le') cpu_type="ppc64le";;
-        'aarch64') cpu_type="arm64";;
-        'armv7l') cpu_type="arm";;
-        *) cpu_type="$machine_hardware_name";;
-    esac
+    # On Apple Silicon, a shell running under Rosetta 2 reports "x86_64".
+    # Detect the translation and correct to the native arm64 so we don't
+    # download an amd64 binary onto arm64 hardware.
+    if [ "$machine_hardware_name" = "x86_64" ] && [ "$(uname)" = "Darwin" ]; then
+        if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+            machine_hardware_name="arm64"
+        fi
+    fi
 
-    echo "$cpu_type"
+    case "$machine_hardware_name" in
+        'x86_64' | 'amd64') echo "amd64";;
+        'aarch64' | 'arm64') echo "arm64";;
+        'powerpc64le' | 'ppc64le') echo "ppc64le";;
+        *) echo "$machine_hardware_name";;
+    esac
 }
 
 get_download_url() {
     local version="$1"
     local platform="$(get_arch)"
-    if [ "$platform" = "darwin" ]; then
-        echo "https://github.com/99designs/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu).dmg"
-    else
-        echo "https://github.com/99designs/aws-vault/releases/download/v${version}/aws-vault-${platform}-$(get_cpu)"
-    fi
+    local cpu="$(get_cpu)"
+    echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/aws-vault-${platform}-${cpu}"
 }
 
 install_aws_vault() {
@@ -49,19 +51,12 @@ install_aws_vault() {
     local bin_path="${bin_install_path}/aws-vault"
     echo "Downloading aws-vault from ${download_url}"
     if curl -sfL "$download_url" -o "$bin_path"; then
-        if [[ "$download_url" = *"dmg" ]]; then
-            # mount
-            hdiutil attach -nobrowse "$bin_path" -quiet
-
-            # replace dmg with binary
-            rm -rf  "$bin_path"
-            cp /Volumes/aws-vault/aws-vault "$bin_path"
-
-            # unmount
-            hdiutil detach /Volumes/aws-vault -quiet
-        fi
-        chmod +x $bin_path
+        chmod +x "$bin_path"
     else
+        rm -f "$bin_path"
+        >&2 echo "Error: could not download aws-vault v${version} for $(get_arch)-$(get_cpu)."
+        >&2 echo "This plugin supports ByteNess binaries from v7.5.0 onward; this version may be unavailable for your platform."
+        >&2 echo "URL: ${download_url}"
         exit 1
     fi
 }

--- a/bin/install
+++ b/bin/install
@@ -1,64 +1,33 @@
 #!/usr/bin/env bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
-ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version  }
-[ -n "$ASDF_INSTALL_VERSION" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
-[ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
 
-get_arch() {
-    uname | tr '[:upper:]' '[:lower:]'
-}
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
 
-get_cpu() {
-    local machine_hardware_name
-    machine_hardware_name="$(uname -m)"
-
-    # On Apple Silicon, a shell running under Rosetta 2 reports "x86_64".
-    # Detect the translation and correct to the native arm64 so we don't
-    # download an amd64 binary onto arm64 hardware.
-    if [ "$machine_hardware_name" = "x86_64" ] && [ "$(uname)" = "Darwin" ]; then
-        if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
-            machine_hardware_name="arm64"
-        fi
-    fi
-
-    case "$machine_hardware_name" in
-        'x86_64' | 'amd64') echo "amd64";;
-        'aarch64' | 'arm64') echo "arm64";;
-        'powerpc64le' | 'ppc64le') echo "ppc64le";;
-        *) echo "$machine_hardware_name";;
-    esac
-}
-
-get_download_url() {
-    local version="$1"
-    local platform="$(get_arch)"
-    local cpu="$(get_cpu)"
-    echo "https://github.com/ByteNess/aws-vault/releases/download/v${version}/aws-vault-${platform}-${cpu}"
-}
+[ -n "${ASDF_INSTALL_VERSION:-}" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
+[ -n "${ASDF_INSTALL_PATH:-}" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
 
 install_aws_vault() {
-    local install_type=$1
-    local version=$2
-    local install_path=$3
-    local bin_install_path="$install_path/bin"
-    local download_url="$(get_download_url $version)"
+    local version="$1"
+    local install_path="$2"
+    local bin_install_path="${install_path}/bin"
+    local bin_path="${bin_install_path}/${TOOL_NAME}"
 
-    mkdir -p "${bin_install_path}"
+    mkdir -p "$bin_install_path"
 
-    local bin_path="${bin_install_path}/aws-vault"
-    echo "Downloading aws-vault from ${download_url}"
-    if curl -sfL "$download_url" -o "$bin_path"; then
-        chmod +x "$bin_path"
+    if [ -n "${ASDF_DOWNLOAD_PATH:-}" ] && [ -f "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}" ]; then
+        # Modern asdf: bin/download already fetched the binary.
+        cp "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}" "$bin_path"
     else
-        rm -f "$bin_path"
-        >&2 echo "Error: could not download aws-vault v${version} for $(get_arch)-$(get_cpu)."
-        >&2 echo "This plugin supports ByteNess binaries from v7.5.0 onward; this version may be unavailable for your platform."
-        >&2 echo "URL: ${download_url}"
-        exit 1
+        # Legacy asdf that runs install without a separate download step.
+        download_binary "$version" "$bin_path"
     fi
+
+    chmod +x "$bin_path"
 }
 
-install_aws_vault $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_aws_vault "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,13 +2,19 @@
 
 set -euo pipefail
 
-function sort_versions() {
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
 list_all_versions() {
-  git ls-remote --tags --refs https://github.com/ByteNess/aws-vault.git |
+  git ls-remote --tags --refs "${GH_REPO}.git" |
     grep -o 'refs/tags/.*' |
     cut -d/ -f3- |
     sed 's/^v//'
@@ -20,11 +26,12 @@ list_all_versions() {
 # Filter to >= 7.5.0: this guarantees an asset for the supported matrix of
 # macOS/Linux on amd64/arm64. The rarer freebsd and linux-ppc64le assets are
 # incomplete even above 7.5.0, so those platforms may still hit the download
-# error in bin/install for some listed versions.
+# error in bin/download for some listed versions.
 # (Uses a portable awk major.minor floor rather than `sort -V`; a non-numeric
 # tag like "experimental" coerces to 0 and is dropped.)
 filter_installable() {
-  awk -F. '($1 + 0 > 7) || ($1 + 0 == 7 && $2 + 0 >= 5)'
+  awk -F. -v maj="$MIN_MAJOR" -v min="$MIN_MINOR" \
+    '($1 + 0 > maj) || ($1 + 0 == maj && $2 + 0 >= min)'
 }
 
 list_all_versions | filter_installable | sort_versions | xargs echo

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,10 +8,23 @@ function sort_versions() {
 }
 
 list_all_versions() {
-  git ls-remote --tags --refs https://github.com/99designs/aws-vault.git |
+  git ls-remote --tags --refs https://github.com/ByteNess/aws-vault.git |
     grep -o 'refs/tags/.*' |
     cut -d/ -f3- |
     sed 's/^v//'
 }
 
-list_all_versions | sort_versions | xargs echo
+# ByteNess inherited all of 99designs' git tags but only publishes the
+# per-platform binaries this plugin installs (aws-vault-<os>-<cpu>) from
+# v7.5.0 onward; earlier tags were released only as tarballs or not at all.
+# Filter to >= 7.5.0: this guarantees an asset for the supported matrix of
+# macOS/Linux on amd64/arm64. The rarer freebsd and linux-ppc64le assets are
+# incomplete even above 7.5.0, so those platforms may still hit the download
+# error in bin/install for some listed versions.
+# (Uses a portable awk major.minor floor rather than `sort -V`; a non-numeric
+# tag like "experimental" coerces to 0 and is dropped.)
+filter_installable() {
+  awk -F. '($1 + 0 > 7) || ($1 + 0 == 7 && $2 + 0 >= 5)'
+}
+
+list_all_versions | filter_installable | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Shared helpers for the aws-vault asdf plugin, sourced by bin/download,
+# bin/install, and bin/list-all.
+
+TOOL_NAME="aws-vault"
+GH_REPO="https://github.com/ByteNess/aws-vault"
+
+# Minimum aws-vault version whose ByteNess release ships the per-platform
+# binaries this plugin installs (aws-vault-<os>-<cpu>). See bin/list-all.
+MIN_MAJOR=7
+MIN_MINOR=5
+
+get_arch() {
+    uname | tr '[:upper:]' '[:lower:]'
+}
+
+get_cpu() {
+    local machine_hardware_name
+    machine_hardware_name="$(uname -m)"
+
+    # On Apple Silicon, a shell running under Rosetta 2 reports "x86_64".
+    # Detect the translation and correct to the native arm64 so we don't
+    # download an amd64 binary onto arm64 hardware.
+    if [ "$machine_hardware_name" = "x86_64" ] && [ "$(uname)" = "Darwin" ]; then
+        if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+            machine_hardware_name="arm64"
+        fi
+    fi
+
+    case "$machine_hardware_name" in
+        'x86_64' | 'amd64') echo "amd64" ;;
+        'aarch64' | 'arm64') echo "arm64" ;;
+        'powerpc64le' | 'ppc64le') echo "ppc64le" ;;
+        *) echo "$machine_hardware_name" ;;
+    esac
+}
+
+get_download_url() {
+    local version="$1"
+    echo "${GH_REPO}/releases/download/v${version}/${TOOL_NAME}-$(get_arch)-$(get_cpu)"
+}
+
+# Download the aws-vault binary for $version into $output_path, failing with a
+# clear message when no matching asset exists.
+download_binary() {
+    local version="$1"
+    local output_path="$2"
+    local url
+    url="$(get_download_url "$version")"
+
+    echo "Downloading ${TOOL_NAME} from ${url}"
+    if ! curl -sfL "$url" -o "$output_path"; then
+        rm -f "$output_path"
+        >&2 echo "Error: could not download ${TOOL_NAME} v${version} for $(get_arch)-$(get_cpu)."
+        >&2 echo "This plugin supports ByteNess binaries from v7.5.0 onward; this version may be unavailable for your platform."
+        >&2 echo "URL: ${url}"
+        exit 1
+    fi
+}


### PR DESCRIPTION
## Why

`99designs/aws-vault` is effectively frozen — last release **v7.2.0 (Mar 2023)**. The maintained fork is **[ByteNess/aws-vault](https://github.com/ByteNess/aws-vault)** (v7.13.3, actively released), which Homebrew, MacPorts, and Chocolatey now ship. This repoints the plugin at ByteNess.

This is a **consolidated fix** that supersedes the three open PRs on the same theme (see below).

## Changes

- **`bin/install`**
  - Download binaries from `ByteNess/aws-vault`.
  - Drop the macOS `.dmg`/`hdiutil` mount-copy-detach block — ByteNess publishes **raw darwin binaries**, not disk images.
  - Fix arch detection: on Apple Silicon under Rosetta 2, `uname -m` reports `x86_64`; detect the translation via `sysctl.proc_translated` and correct to `arm64`. Intel stays on `amd64`.
  - Fail with a clear, actionable error (version, platform, URL) instead of a bare `exit 1`, and clean up the partial file.
- **`bin/list-all`**
  - Resolve versions from `ByteNess/aws-vault`.
  - Floor the list at **v7.5.0** — the first release with the per-platform binary layout this plugin installs (`aws-vault-<os>-<cpu>`). Older inherited tags were tarball-only or had no assets, so listing them produced uninstallable versions.
- **`README.md`** — link upstream to ByteNess, add a **Supported platforms** section (macOS/Linux on amd64/arm64), fix the `Crediits` typo.

## Support matrix

Verified across all 76 advertised (≥ 7.5.0) versions: **darwin & linux amd64/arm64 have zero asset gaps**. FreeBSD and Linux `ppc64le` assets are incomplete even above 7.5.0, so those platforms are best-effort and fall through to the clear install error.

## Verification

- `bash -n` clean on both scripts.
- End-to-end install of `7.13.3` and `7.5.0` on darwin/arm64 → correct binary, reports right version.
- Unavailable version (e.g. `6.6.0`) → loud error + `exit 1`, no leftover file.
- `list-all` → 76 versions, `7.5.0`…`7.13.3`, non-semver tags dropped.

## Supersedes

Consolidates and replaces:
- #11 (@particledecay) — switch to ByteNess
- #10 (@elijahr) — switch to ByteNess + Windows support
- #8 (@JBOClara) — arch detection

Thanks to all three for the groundwork. Closing those in favor of this once merged.